### PR TITLE
Emit new child class in @Module decorator

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -16,13 +16,15 @@ function moduleDecoratorFactory(moduleOptions?: ModuleOptions) {
   return <TFunction extends Function>(constructor: TFunction): TFunction => {
     const accessor: any = function(...args: any[]) {
       const instance = new constructor.prototype.constructor(...args) as IVuexModule;
+      Object.setPrototypeOf(instance, accessor.prototype);
 
       const factory = new VuexClassModuleFactory(constructor, instance, moduleOptions || {});
 
       factory.registerVuexModule();
       return factory.buildAccessor();
     };
-    accessor.prototype = constructor.prototype;
+    accessor.prototype = Object.create(constructor.prototype);
+    accessor.prototype.constructor = accessor;
     return accessor;
   };
 }

--- a/test/instanceof.ts
+++ b/test/instanceof.ts
@@ -5,17 +5,19 @@ import Vue from "vue";
 Vue.use(Vuex);
 const store = new Vuex.Store<any>({});
 
-@Module
-class MyModule extends VuexModule {
+class OriginalModule extends VuexModule {
   foo = {
     text: "some text"
   };
   bar = 1;
 }
 
+/** Manually apply decorator, to have access to initial class definition */
+const MyModule = Module(OriginalModule);
 const myModule = new MyModule({ store, name: "myModule" });
 
 test("instance of", () => {
+  expect(myModule instanceof OriginalModule).toBe(true);
   expect(myModule instanceof MyModule).toBe(true);
   expect(myModule instanceof VuexModule).toBe(true);
 });


### PR DESCRIPTION
Instead of reusing the prototype of the constructor to be decorated
directly, we create a child class and thus keep the whole original class
intact.

Previously any metadata on the undecorated module class was lost. Now it
lives on in the prototype chain.
Cf. https://github.com/rbuckton/reflect-metadata

Fixes #9