### PR TITLE
Fix $watch for state changes

### DIFF
--- a/src/module-factory.ts
+++ b/src/module-factory.ts
@@ -194,7 +194,7 @@ export class VuexClassModuleFactory {
       options?: WatchOptions
     ) => {
       store.watch(
-        (state: any, getters: any) => fn(this.buildThisProxy({ state, getters, useNamespaceKey: true })),
+        (state: any, getters: any) => fn(this.buildThisProxy({ state: state[name], getters, useNamespaceKey: true })),
         callback,
         options
       );

--- a/test/watch.ts
+++ b/test/watch.ts
@@ -30,12 +30,26 @@ describe("watch", () => {
   test("watch callback is called", async () => {
     const watchCallback = jest.fn((newValue: string, oldValue: string) => undefined);
 
+    myModule.setText("bar")
     myModule.$watch(theModule => theModule.getText, watchCallback);
     await myModule.changeText("foo");
 
     expect(watchCallback.mock.calls.length).toBe(1);
     expect(watchCallback.mock.calls[0].length).toBe(2);
     expect(watchCallback.mock.calls[0][0]).toBe("foo");
-    expect(watchCallback.mock.calls[0][1]).toBe("");
+    expect(watchCallback.mock.calls[0][1]).toBe("bar");
+  });
+
+  test("watch for state changes as well", async () => {
+    const watchCallback = jest.fn((newValue: string, oldValue: string) => undefined);
+
+    myModule.setText("bar")
+    myModule.$watch(theModule => theModule.text, watchCallback);
+    await myModule.changeText("foo");
+
+    expect(watchCallback.mock.calls.length).toBe(1);
+    expect(watchCallback.mock.calls[0].length).toBe(2);
+    expect(watchCallback.mock.calls[0][0]).toBe("foo");
+    expect(watchCallback.mock.calls[0][1]).toBe("bar");
   });
 });


### PR DESCRIPTION
Closes https://github.com/gertqin/vuex-class-modules/issues/15

What updated:

- Pass in `state: state[name]` to `this.buildThisProxy()` when creating the `$watch` function.
- Add a test to prove this change.

