### PR TITLE
Fix issue with getters when inheriting

### DIFF
--- a/src/module-factory.ts
+++ b/src/module-factory.ts
@@ -94,11 +94,11 @@ export class VuexClassModuleFactory {
         }
 
         const isHelperFunction =
-            descriptor.value &&
-            typeof module.prototype[key] === "function" &&
-            actionKeys.indexOf(key) === -1 &&
-            mutationKeys.indexOf(key) === -1 &&
-            key !== "constructor";
+          descriptor.value &&
+          typeof module.prototype[key] === "function" &&
+          actionKeys.indexOf(key) === -1 &&
+          mutationKeys.indexOf(key) === -1 &&
+          key !== "constructor";
 
         if (isHelperFunction) {
           this.definition.localFunctions[key] = module.prototype[key];

--- a/test/actions-inheritance.ts
+++ b/test/actions-inheritance.ts
@@ -1,0 +1,100 @@
+import { Action, Module, Mutation, VuexModule } from "../src";
+import Vuex, { Store } from "vuex";
+import Vue from "vue";
+
+Vue.use(Vuex);
+
+class ParentModule extends VuexModule {
+  foo = "init";
+
+  get bigFoo() {
+    return this.foo.toUpperCase();
+  }
+
+  @Mutation
+  updateFoo(value: string) {
+    this.foo = value;
+  }
+
+  @Action
+  action1() {
+    //
+  }
+
+  @Action
+  action2() {
+    //
+  }
+
+  @Action
+  action3() {
+    //
+  }
+
+  @Action
+  action4() {
+    //
+  }
+}
+
+@Module
+class MyModule extends ParentModule {
+  get doubledFoo() {
+    return this.foo + this.foo;
+  }
+
+  @Mutation
+  setFooToExample() {
+    this.foo = "example";
+  }
+
+  @Action
+  action1() {
+    this.setFooToExample();
+  }
+
+  @Action
+  action2() {
+    this.updateFoo("bar");
+  }
+
+  @Action
+  action3() {
+    this.updateFoo(this.doubledFoo);
+  }
+
+  @Action
+  action4() {
+    this.updateFoo(this.bigFoo);
+  }
+}
+
+describe("actions-inheritance", () => {
+  let store: Store<any>;
+  let myModule: MyModule;
+
+  beforeEach(() => {
+    store = new Vuex.Store({});
+    myModule = new MyModule({ store, name: "myModule" });
+  });
+
+  test("overriden action has access to mutations", () => {
+    myModule.action1();
+    expect(myModule.foo).toBe("example");
+  });
+
+  test("overriden action has access to parent mutations", () => {
+    myModule.action2();
+    expect(myModule.foo).toBe("bar");
+  });
+
+  test("overriden action has access to getters", () => {
+    myModule.action3();
+    expect(myModule.foo).toBe("initinit");
+  });
+
+  test("overriden action has access to parent getters", () => {
+    myModule.action4();
+    expect(myModule.foo).toBe("INIT");
+  });
+});

--- a/test/actions-inheritance.ts
+++ b/test/actions-inheritance.ts
@@ -35,10 +35,17 @@ class ParentModule extends VuexModule {
   action4() {
     //
   }
+
+  @Action
+  action5() {
+    this.updateFoo(this.foo + "action5");
+  }
 }
 
 @Module
 class MyModule extends ParentModule {
+  bar: string = "";
+
   get doubledFoo() {
     return this.foo + this.foo;
   }
@@ -66,6 +73,12 @@ class MyModule extends ParentModule {
   @Action
   action4() {
     this.updateFoo(this.bigFoo);
+  }
+
+  @Action
+  action5() {
+    super.action5();
+    this.updateFoo(this.foo + "child");
   }
 }
 
@@ -96,5 +109,10 @@ describe("actions-inheritance", () => {
   test("overriden action has access to parent getters", () => {
     myModule.action4();
     expect(myModule.foo).toBe("INIT");
+  });
+
+  test("overriden action has access to parent method implementation", () => {
+    myModule.action5();
+    expect(myModule.foo).toBe("initaction5child");
   });
 });

--- a/test/getters-inheritance.ts
+++ b/test/getters-inheritance.ts
@@ -29,7 +29,7 @@ class MyModule extends ParentModule {
   //
 }
 
-describe.only("getters-inheritance", () => {
+describe("getters-inheritance", () => {
   let store: Store<any>;
   let myModule: MyModule;
 

--- a/test/getters-inheritance.ts
+++ b/test/getters-inheritance.ts
@@ -1,0 +1,51 @@
+import { Action, Module, Mutation, VuexModule } from "../src";
+import Vuex, { Store } from "vuex";
+import Vue from "vue";
+
+Vue.use(Vuex);
+
+class ParentModule extends VuexModule {
+  foo = "bar";
+
+  get textTransforms() {
+    return this.foo.toUpperCase();
+  }
+
+  @Mutation
+  myMutation(value: string) {
+    this.foo = value;
+  }
+
+  @Action
+  myAction() {
+    if (this.textTransforms === "BAR") {
+      this.myMutation("ok");
+    }
+  }
+}
+
+@Module
+class MyModule extends ParentModule {
+  //
+}
+
+describe.only("getters-inheritance", () => {
+  let store: Store<any>;
+  let myModule: MyModule;
+
+  beforeEach(() => {
+    store = new Vuex.Store({});
+    myModule = new MyModule({ store, name: "myModule" });
+  });
+
+  test("allows the use of getters from an inheriting class", () => {
+    expect(myModule.textTransforms).toBe("BAR");
+    expect(myModule.textTransforms).toBe(store.getters["myModule/textTransforms"]);
+  });
+
+  test("allows the use of getters in inherited class", () => {
+    myModule.myAction();
+    expect(myModule.textTransforms).toBe("OK");
+    expect(myModule.textTransforms).toBe(store.getters["myModule/textTransforms"]);
+  });
+});

--- a/test/getters-inheritance.ts
+++ b/test/getters-inheritance.ts
@@ -7,7 +7,7 @@ Vue.use(Vuex);
 class ParentModule extends VuexModule {
   foo = "bar";
 
-  get textTransforms() {
+  get bigFoo() {
     return this.foo.toUpperCase();
   }
 
@@ -18,7 +18,7 @@ class ParentModule extends VuexModule {
 
   @Action
   myAction() {
-    if (this.textTransforms === "BAR") {
+    if (this.bigFoo === "BAR") {
       this.myMutation("ok");
     }
   }
@@ -39,13 +39,13 @@ describe("getters-inheritance", () => {
   });
 
   test("allows the use of getters from an inheriting class", () => {
-    expect(myModule.textTransforms).toBe("BAR");
-    expect(myModule.textTransforms).toBe(store.getters["myModule/textTransforms"]);
+    expect(myModule.bigFoo).toBe("BAR");
+    expect(myModule.bigFoo).toBe(store.getters["myModule/bigFoo"]);
   });
 
   test("allows the use of getters in inherited class", () => {
     myModule.myAction();
-    expect(myModule.textTransforms).toBe("OK");
-    expect(myModule.textTransforms).toBe(store.getters["myModule/textTransforms"]);
+    expect(myModule.bigFoo).toBe("OK");
+    expect(myModule.bigFoo).toBe(store.getters["myModule/bigFoo"]);
   });
 });

--- a/test/mutations-inheritance.ts
+++ b/test/mutations-inheritance.ts
@@ -16,6 +16,11 @@ class ParentModule extends VuexModule {
   mutation2(value: string) {
     //
   }
+
+  @Mutation
+  mutation3(value: string) {
+    this.foo = value;
+  }
 }
 
 @Module
@@ -30,6 +35,12 @@ class MyModule extends ParentModule {
   @Mutation
   mutation2(value: string) {
     this.foo = value;
+  }
+
+  @Mutation
+  mutation3(value: string) {
+    super.mutation3(value);
+    this.foo = this.foo + "child";
   }
 }
 
@@ -50,5 +61,10 @@ describe("mutations-inheritance", () => {
   test("overriden mutation can modify parent state", () => {
     myModule.mutation2("bar");
     expect(myModule.foo).toBe("bar");
+  });
+
+  test("overriden mutation has access to parent method implementation", () => {
+    myModule.mutation3("bar");
+    expect(myModule.foo).toBe("barchild");
   });
 });

--- a/test/mutations-inheritance.ts
+++ b/test/mutations-inheritance.ts
@@ -1,0 +1,54 @@
+import { Module, Mutation, VuexModule } from "../src";
+import Vuex, { Store } from "vuex";
+import Vue from "vue";
+
+Vue.use(Vuex);
+
+class ParentModule extends VuexModule {
+  foo = "init";
+
+  @Mutation
+  mutation1(value: string) {
+    //
+  }
+
+  @Mutation
+  mutation2(value: string) {
+    //
+  }
+}
+
+@Module
+class MyModule extends ParentModule {
+  baz = "init";
+
+  @Mutation
+  mutation1(value: string) {
+    this.baz = value;
+  }
+
+  @Mutation
+  mutation2(value: string) {
+    this.foo = value;
+  }
+}
+
+describe("mutations-inheritance", () => {
+  let store: Store<any>;
+  let myModule: MyModule;
+
+  beforeEach(() => {
+    store = new Vuex.Store({});
+    myModule = new MyModule({ store, name: "myModule" });
+  });
+
+  test("overriden mutation can modify state", () => {
+    myModule.mutation1("bar");
+    expect(myModule.baz).toBe("bar");
+  });
+
+  test("overriden mutation can modify parent state", () => {
+    myModule.mutation2("bar");
+    expect(myModule.foo).toBe("bar");
+  });
+});


### PR DESCRIPTION
This PR solves a problem with using getters in inherited classes. Problem is solved by iterating over prototype chain until `VuexModule` class.

This PR solves https://github.com/gertqin/vuex-class-modules/issues/13