### PR TITLE
Use commonjs module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "es2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "lib": [
       "dom",


### PR DESCRIPTION
This PR solves issue with using `vuex-class-modules` along with `jest` testing framework. Unfortunately Jest does not play well with ES6 module syntax. You can read more here: https://github.com/facebook/jest/issues/2550#issuecomment-381718006

I think it's common approach to use `commonjs` module instead of `es6` one.
