### PR TITLE
Adds "./package.json" to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     ".": {
       "require": "./commonjs/index.js",
       "default": "./lib/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
Updates from 1.2.0+ fail when building with Webpack 5/node 16 due to `Package subpath './package.json' is not defined by "exports" in [...]/node_modules/vuex-class-modules/package.json`